### PR TITLE
Single-line fix

### DIFF
--- a/train_elastic_net.py
+++ b/train_elastic_net.py
@@ -79,7 +79,7 @@ print(normed_source_matrix.shape)
 
 # Load source data labels
 y_file = os.path.join(data_dir, "source_y.tsv")
-y_table = pd.read_csv(y_file)
+y_table = pd.read_csv(y_file, header=None)
 y_matrix = np.asfortranarray(y_table)
 
 if args.horvath:


### PR DESCRIPTION
I wasn't setting header=None for one of the data files and it was causing a collision when the x and y dimensions didn't match.